### PR TITLE
Removing ORG since it is not required

### DIFF
--- a/pii_scan.py
+++ b/pii_scan.py
@@ -209,33 +209,6 @@ def create_analyzer():
     genders_recognizer = PatternRecognizer(supported_entity='GENDER', deny_list=genders_list)
     registry.add_recognizer(genders_recognizer)
 
-    # Customize SpacyRecognizer to include some additional labels
-    # First remove the default SpacyRecognizer
-    registry.remove_recognizer("SpacyRecognizer")
-
-    # Add ORGANIZATION as an entity even though it is not recommended
-    entities = [
-        "DATE_TIME",
-        "NRP",
-        "LOCATION",
-        "PERSON",
-        "ORGANIZATION",
-        "USERNAME"
-    ]
-    # Add FAC to be identified as a location
-    # FAC = buildings, airports, highways, bridges, etc
-    label_groups = [
-        ({"LOCATION"}, {"GPE", "LOC", "FAC"}),
-        ({"PERSON", "PER"}, {"PERSON", "PER"}),
-        ({"DATE_TIME"}, {"DATE", "TIME"}),
-        ({"NRP"}, {"NORP"}),
-        ({"ORGANIZATION"}, {"ORG"}),
-        ({"USERNAME"}, {"USER"})
-    ]
-    # noinspection PyTypeChecker
-    spacy_recognizer = SpacyRecognizer(check_label_groups=label_groups, supported_entities=entities)
-    registry.add_recognizer(spacy_recognizer)
-
     # create a custom US_SSN recognizer
     # Remove the default US_SSN recognizer
     registry.remove_recognizer('UsSsnRecognizer')
@@ -253,9 +226,7 @@ analyzer = create_analyzer()
 
 def analyze_text(text: str, show_supported=False, show_details=False, score_threshold=0.0) -> \
         list[str] | list[RecognizerResult]:
-    # Add ORGANIZATION to the list of labels to be checked
     labels = analyzer.get_supported_entities()
-    labels.append('ORGANIZATION')
 
     # Show all entities that can be detected for debugging
     if show_supported:

--- a/test_pii_scan.py
+++ b/test_pii_scan.py
@@ -31,25 +31,15 @@ class TestPIIScan(unittest.TestCase):
         results = analyze_text('This is not a UUID: 123e4567-e89b-12d3-a456-42665234000')
         self.assertNotIn('UUID', str(results))
 
-    def test_organization(self):
-        # test a valid organization
-        # results = analyze_text('This is an organization: Texas A&M University')
-        # Latest version of en_core_web_lg not detecting this as an ORGANIZTION
-        # todo: figure out why not
-        # self.assertIn('ORGANIZATION', str(results))
-        # test an invalid organization
-        results = analyze_text('This is not an organization: Jones and Smith')
-        self.assertNotIn('ORGANIZATION', str(results))
-
     def test_base_supported_entities(self):
         """Test to make sure the default supported entities are returned"""
         results = analyze_text('', show_supported=True)
+        print(results)
         supported_entities = ['IP_ADDRESS',
                               'MEDICAL_LICENSE',
                               'LOCATION',
                               'EMAIL_ADDRESS',
                               'DATE_TIME',
-                              'ORGANIZATION',
                               'CREDIT_CARD',
                               'CRYPTO',
                               'AU_MEDICARE',
@@ -69,7 +59,6 @@ class TestPIIScan(unittest.TestCase):
                               'UUID',
                               'US_DRIVER_LICENSE',
                               'AU_ACN',
-                              'ORGANIZATION',
                               'STUDENT_ID',
                               'USERNAME'
                               ]
@@ -90,3 +79,7 @@ class TestPIIScan(unittest.TestCase):
                         if m:
                             self.assertTrue(m.group(1).startswith('test'),
                                             'Method name does not start with test: def ' + m.group(1) + ' in ' + file)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Presidio updates deprecated using check_label_groups.  Since ORG is not being used will simply remove it to solve the warning.